### PR TITLE
fixed: go get was not working

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"golang.org/x/sys/windows/registry"
-	"gvm/web"
+	"github.com/danielkermode/gvm/web"
 	"io/ioutil"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
$ go get github.com/danielkermode/gvm
package gvm/web: unrecognized import path "gvm/web" (import path does not begin with hostname)

this was happening on my machine (window, git bash, go version go1.11 windows/amd64)