### PR TITLE
replace system architecture string x86 to 386.

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,10 @@ func main() {
 	osArch := strings.ToLower(os.Getenv("PROCESSOR_ARCHITECTURE"))
 	detail := ""
 
+	if osArch == "x86" {
+		osArch = "386"
+	}
+
 	if len(args) < 2 {
 		help()
 		return


### PR DESCRIPTION
On my wiindows10(32bit), `SYSTEM_ARCHITECTURE` has set to `x86` as default. but the remote filepath of  architecture string is `386` and could not download that.
Sorry for my bad english.

